### PR TITLE
Fix Inverse Matrix commit

### DIFF
--- a/matrix.c
+++ b/matrix.c
@@ -2,15 +2,9 @@
 
 
 /* <-------------------------------------------------------- Local Functions --------------------------------------------------------> */
-static unsigned short int _min( unsigned short int num1, unsigned short int num2 )
+static float _fab( float num )
 {
-   if( num1 < num2 ) return num1;
-   if( num2 < num1 ) return num2;
-   else return num1;
-}
 
-static int _fab( float num )
-{
    if( num < 0.0f )
       return -num;
    else

--- a/matrix.h
+++ b/matrix.h
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#define EPSILON 0.000000001
+#define EPSILON 1e-9
 
 typedef struct MatrixFloatStruct{
    unsigned short int rows;


### PR DESCRIPTION
-matrix.c
--Fixed: _fab, wrong return type creating errors in inverse_matrix function RESOLUTION: changed return type to float --Removed: _min, no longer used

-matrix.h
--Modified: EPSILON to 1e-9